### PR TITLE
Move Embed link above JSON State of game

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -61,11 +61,12 @@
   </div>
 </div>
 
+<h3>Embed</h3>
+<input style="width: 100%" readonly id="embed-copy" />
+
 <div
   id="state"
   class="my-3"
   style="width: 100%; height: auto; white-space: pre-wrap; display: block"
 ></div>
 
-<h3>Embed</h3>
-<input style="width: 100%" readonly id="embed-copy" />


### PR DESCRIPTION
Moved Embed link above where the JSON of the State of the game. 
Tiny change that makes it easier and less annoying to find and copy the link, making it right in front of instead of scrolling through an entire JSON document.